### PR TITLE
Add ball interaction menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,6 +11,13 @@
 
     <button id="menuButton">Menú</button>
 
+    <div id="ballOptions" class="ball-options">
+      <button id="deleteBallBtn">Eliminar</button>
+      <button id="growBallBtn">Agrandar</button>
+      <button id="speedUpBallBtn">Más rápido</button>
+      <button id="slowDownBallBtn">Más lento</button>
+    </div>
+
     <div id="customizationModal" class="modal">
       <div class="modal-content">
         <span class="close-button">&times;</span>

--- a/scripts/config.js
+++ b/scripts/config.js
@@ -16,6 +16,11 @@ export const speedValueSpan = document.getElementById('speedValue');
 export const addBallBtn = document.getElementById('addBallBtn');
 export const resetBallsBtn = document.getElementById('resetBallsBtn');
 export const toggleShapeBtn = document.getElementById('toggleShapeBtn');
+export const ballOptionsDiv = document.getElementById('ballOptions');
+export const deleteBallBtn = document.getElementById('deleteBallBtn');
+export const growBallBtn = document.getElementById('growBallBtn');
+export const speedUpBallBtn = document.getElementById('speedUpBallBtn');
+export const slowDownBallBtn = document.getElementById('slowDownBallBtn');
 
 // Ajustar canvas size to window
 canvas.width = window.innerWidth;

--- a/scripts/ui-handlers.js
+++ b/scripts/ui-handlers.js
@@ -8,10 +8,18 @@ import {
     // Importaciones de elementos DOM directamente desde config.js
     menuButton, closeButton, toggleSnakeModeBtn, toggleCollisionsBtn,
     colorPaletteBtns, speedRange, speedValueSpan, addBallBtn,
-    resetBallsBtn, toggleShapeBtn
+    resetBallsBtn, toggleShapeBtn,
+    ballOptionsDiv, deleteBallBtn, growBallBtn, speedUpBallBtn, slowDownBallBtn
 } from './config.js';
 import { addBall, initializeBalls, handleWindowResize } from './ball-manager.js';
 import { getColorForPalette } from './utils.js';
+
+let selectedBall = null;
+
+function hideBallOptions() {
+    ballOptionsDiv.style.display = 'none';
+    selectedBall = null;
+}
 
 
 // --- Menu Button Show/Hide Logic ---
@@ -49,18 +57,23 @@ canvas.addEventListener('click', (event) => {
     const clickX = event.clientX - rect.left;
     const clickY = event.clientY - rect.top;
 
+    selectedBall = null;
     for (let i = 0; i < balls.length; i++) {
         const ball = balls[i];
         const distance = Math.sqrt((clickX - ball.x) ** 2 + (clickY - ball.y) ** 2);
 
         if (distance < ball.radius) {
-            if (ball.sizeState === 'normal' && ball.radius === ball.minRadius) {
-                ball.sizeState = 'growing';
-            } else {
-                ball.sizeState = 'shrinking';
-            }
+            selectedBall = ball;
             break;
         }
+    }
+
+    if (selectedBall) {
+        ballOptionsDiv.style.left = `${event.clientX}px`;
+        ballOptionsDiv.style.top = `${event.clientY}px`;
+        ballOptionsDiv.style.display = 'flex';
+    } else {
+        hideBallOptions();
     }
 });
 
@@ -72,17 +85,23 @@ menuButton.addEventListener('click', () => {
     showButton();
     clearTimeout(hideButtonTimeout);
     setHideButtonTimeout(null); // Detener el temporizador mientras el modal está abierto
+    hideBallOptions();
 });
 
 closeButton.addEventListener('click', () => {
     customizationModal.classList.remove('open');
     showButtonAndResetTimer();
+    hideBallOptions();
 });
 
 window.addEventListener('click', (event) => {
     if (event.target === customizationModal) {
         customizationModal.classList.remove('open');
         showButtonAndResetTimer();
+    }
+
+    if (!ballOptionsDiv.contains(event.target) && event.target !== canvas) {
+        hideBallOptions();
     }
 });
 
@@ -142,6 +161,43 @@ toggleShapeBtn.addEventListener('click', () => {
     });
     customizationModal.classList.remove('open');
     showButtonAndResetTimer();
+});
+
+deleteBallBtn.addEventListener('click', () => {
+    if (selectedBall) {
+        const index = balls.indexOf(selectedBall);
+        if (index !== -1) {
+            balls.splice(index, 1);
+        }
+    }
+    hideBallOptions();
+});
+
+growBallBtn.addEventListener('click', () => {
+    if (selectedBall) {
+        selectedBall.sizeState = 'growing';
+    }
+    hideBallOptions();
+});
+
+speedUpBallBtn.addEventListener('click', () => {
+    if (selectedBall) {
+        selectedBall.baseDx *= 1.5;
+        selectedBall.baseDy *= 1.5;
+        selectedBall.dx = selectedBall.baseDx * currentSpeedMultiplier;
+        selectedBall.dy = selectedBall.baseDy * currentSpeedMultiplier;
+    }
+    hideBallOptions();
+});
+
+slowDownBallBtn.addEventListener('click', () => {
+    if (selectedBall) {
+        selectedBall.baseDx *= 0.75;
+        selectedBall.baseDy *= 0.75;
+        selectedBall.dx = selectedBall.baseDx * currentSpeedMultiplier;
+        selectedBall.dy = selectedBall.baseDy * currentSpeedMultiplier;
+    }
+    hideBallOptions();
 });
 
 window.addEventListener("resize", handleWindowResize);

--- a/style.css
+++ b/style.css
@@ -39,6 +39,32 @@ canvas {
     pointer-events: none;
 }
 
+/* Opciones cuando se toca una pelota */
+.ball-options {
+    position: absolute;
+    display: none;
+    flex-direction: column;
+    gap: 5px;
+    background: rgba(255, 255, 255, 0.9);
+    border: 1px solid #888;
+    border-radius: 8px;
+    padding: 8px;
+    z-index: 15;
+}
+
+.ball-options button {
+    padding: 6px 10px;
+    cursor: pointer;
+    border: none;
+    border-radius: 5px;
+    background-color: #007bff;
+    color: white;
+}
+
+.ball-options button:hover {
+    background-color: #0056b3;
+}
+
 /* --- Estilos del Modal --- */
 .modal {
     display: none;


### PR DESCRIPTION
## Summary
- add contextual menu with buttons to delete or change a ball
- style new ball action menu
- expose new DOM elements in config
- implement handlers to show/hide the menu and perform actions

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68675ed3b4808321994560d8cd7ffb79